### PR TITLE
fix: label not updated

### DIFF
--- a/content/docs/primitives/2.components/1.label/0.0.1.md
+++ b/content/docs/primitives/2.components/1.label/0.0.1.md
@@ -1,5 +1,5 @@
 ---
-title: Label (0.1.0)
+title: Label (0.0.1)
 description: Renders an accessible label associated with controls.
 icon: i-ph-triangle-thin
 version: 0.0.1
@@ -13,6 +13,8 @@ root: false
 #code
 codegen{src="components/package/label/Demo.vue" lang="vue"}
 ::
+
+testing this is 0.0.1
 
 ## Installation
 


### PR DESCRIPTION
Relate to: https://github.com/oku-ui/docs/issues/9

I think you might be confused with the label, and thought why is it not updating.

I've modified the title of `0.0.1`, and added a line to make sure it does render the correct version. Do have a look!

Cheers!