### PR TITLE
fix: router-link-active class not available when navigating in child path

### DIFF
--- a/components/SideNavBar.vue
+++ b/components/SideNavBar.vue
@@ -2,10 +2,13 @@
 const { data } = await useAsyncData('nav', () =>
   queryContent('/docs/primitives').where({ root: true }).only(['title', '_path', '_dir', 'root']).find(),
 )
+const { path } = toRefs(useRoute())
 
 const tree = computed(() => {
   return data.value?.reduce((result, currentObject) => {
     const key = currentObject._dir
+    currentObject.active = path.value.includes(currentObject._path)
+
     if (!result[key])
       result[key] = []
 
@@ -22,7 +25,7 @@ const tree = computed(() => {
         {{ key }}
       </h4>
 
-      <NuxtLink v-for="item in child" :key="item" :to="item._path" class="mt-2 text-sm flex flex-col space-y-1  p-2 font-semibold hover:text-oku-300  hover:border-l-5 hover:border-oku-500">
+      <NuxtLink v-for="item in child" :key="item" :to="item._path" :class="{ 'router-link-active': item.active }" class="mt-2 text-sm flex flex-col space-y-1  p-2 font-semibold hover:text-oku-300  hover:border-l-5 hover:border-oku-500">
         {{
           item.title
         }}

--- a/content/docs/primitives/2.components/1.label/0.0.1.md
+++ b/content/docs/primitives/2.components/1.label/0.0.1.md
@@ -1,5 +1,5 @@
 ---
-title: Label (0.1.0)
+title: Label (0.0.1)
 description: Renders an accessible label associated with controls.
 icon: i-ph-triangle-thin
 version: 0.0.1
@@ -13,6 +13,8 @@ root: false
 #code
 codegen{src="components/package/label/Demo.vue" lang="vue"}
 ::
+
+testing this is 0.0.1
 
 ## Installation
 


### PR DESCRIPTION
Due to this issue, https://github.com/nuxt/nuxt/issues/14042, the `router-link-active` missing when we navigate to child `version` path.

Here's a simple workaround