### PR TITLE
feat: remove team

### DIFF
--- a/.vitepress/components/Contributors.vue
+++ b/.vitepress/components/Contributors.vue
@@ -1,25 +1,56 @@
 <script setup lang="ts">
+import { AvatarFallback, AvatarImage, AvatarRoot, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from '@oku-ui/primitives'
 import { contributors } from '../contributors'
+
+function getInitials(name: string) {
+  return name.match(/\b[A-Z]/gi)?.join('') ?? name[0]
+}
 </script>
 
 <template>
-  <div class="flex flex-wrap gap-2 justify-center">
-    <a
-      v-for="{ name, avatar } of contributors"
-      :key="name"
-      :href="`https://github.com/${name}`"
-      class="m-0"
-      rel="noopener noreferrer"
-      :aria-label="`${name} on GitHub`"
-    >
-      <img
-        loading="lazy"
-        :src="avatar"
-        width="50"
-        height="50"
-        class="rounded-full h-12 w-12"
-        :alt="`${name}'s avatar`"
+  <div class="flex flex-wrap gap-4 justify-center my-8 not-prose">
+    <TooltipProvider>
+      <TooltipRoot
+        v-for="{ name, avatar } of contributors"
+        :key="name"
+        :delay-duration="0"
+        :disable-hoverable-content="true"
       >
-    </a>
+        <TooltipTrigger as="template">
+          <AvatarRoot as="template">
+            <a
+              :href="`https://github.com/${name}`"
+              class="group relative inline-flex items-center justify-center"
+              rel="noopener noreferrer"
+              :aria-label="`${name} on GitHub`"
+              target="_blank"
+            >
+              <div
+                class="h-14 w-14 rounded-full overflow-hidden bg-gradient-to-br from-green-400 via-blue-500 to-purple-600 flex items-center justify-center shadow-lg transform transition-all group-hover:scale-110"
+              >
+                <AvatarImage
+                  :src="avatar"
+                  :alt="`${name}'s avatar`"
+                  class="h-full w-full object-cover"
+                />
+                <AvatarFallback
+                  class="text-center uppercase text-sm font-semibold text-white"
+                  :delay-ms="1000"
+                >
+                  {{ getInitials(name) }}
+                </AvatarFallback>
+              </div>
+            </a>
+          </AvatarRoot>
+        </TooltipTrigger>
+
+        <TooltipContent
+          class="text-xs font-semibold text-white px-3 py-1 rounded bg-gray-800 border border-gray-600 shadow-md transform transition-opacity duration-200"
+          side="bottom"
+        >
+          {{ name }}
+        </TooltipContent>
+      </TooltipRoot>
+    </TooltipProvider>
   </div>
 </template>

--- a/.vitepress/components/HomePage.vue
+++ b/.vitepress/components/HomePage.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { VPTeamMembers } from 'vitepress/theme-without-fonts'
-import { teamMembers } from '../contributors'
 import Contributors from './Contributors.vue'
 </script>
 
@@ -10,22 +8,10 @@ import Contributors from './Contributors.vue'
       <main class="w-full">
         <div class="vp-doc flex flex-col items-center mt-10">
           <h2
-            id="meet-the-team"
-            class="opacity-50 font-medium pt-10 pb-2"
-          >
-            Meet The Team
-          </h2>
-          <div class="w-full">
-            <VPTeamMembers
-              size="small"
-              :members="teamMembers"
-            />
-          </div>
-          <h2
             id="the-team"
-            class="op50 font-medium pt-5 pb-2"
+            class="font-medium pt-5 pb-2"
           >
-            Contributors
+            Crafted with passion by Vue enthusiasts 💚
           </h2>
           <p class="text-lg max-w-200 text-center leading-7">
             <Contributors />


### PR DESCRIPTION
“Removed the ‘team’ mention from all Oku sites and replaced it with:
Crafted with passion by Vue enthusiasts 💚

Because we believe this phrase better represents the love and dedication behind the project.”